### PR TITLE
Changed the step filters in SNV to 0.001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.0.6
+- SNV filter step size has been changed to 0.001, now user can go upto 0.1% at the lowest.
+
 ## v3.0.5
 - Download of csv file from Coyot3 #109
 - Sort Variants in Report Table by Tier and VAF #107

--- a/coyote/__version__.py
+++ b/coyote/__version__.py
@@ -17,7 +17,7 @@ Version Information for Coyote3
 This file contains the version information for the Coyote3 application.
 """
 
-__version__ = "3.0.5"
+__version__ = "3.0.6"
 
 # For easier access by build-scripts:
 if __name__ == "__main__":

--- a/coyote/blueprints/dna/templates/variant_sidebars.html
+++ b/coyote/blueprints/dna/templates/variant_sidebars.html
@@ -82,7 +82,7 @@
         <label class="text-gray-900">Min Freq.</label>
         <div class="flex items-center gap-1">
           <span class="text-sm font-bold">&ge;</span>
-          {{ form.min_freq(size=1, step="0.01", min=0, max=1, default=sample.filters.min_freq, class="border border-gray-400 rounded px-1 py-0.5 w-16") }}
+          {{ form.min_freq(size=1, step="0.001", min=0, max=1, default=sample.filters.min_freq, class="border border-gray-400 rounded px-1 py-0.5 w-16") }}
         </div>
       </div>
 
@@ -90,7 +90,7 @@
         <label class="text-gray-900">Max Freq.</label>
         <div class="flex items-center gap-1">
           <span class="text-sm font-bold">&le;</span>
-          {{ form.max_freq(size=1, step="0.01", min=0, max=1, default=sample.filters.max_freq, class="border border-gray-400 rounded px-1 py-0.5 w-16") }}
+          {{ form.max_freq(size=1, step="0.001", min=0, max=1, default=sample.filters.max_freq, class="border border-gray-400 rounded px-1 py-0.5 w-16") }}
         </div>
       </div>
 
@@ -98,7 +98,7 @@
         <label class="text-gray-900">Max Ctrl. Freq.</label>
         <div class="flex items-center gap-1">
           <span class="text-sm font-bold">&le;</span>
-          {{ form.max_control_freq(size=1, step="0.01", min=0, max=1, default=sample.filters.max_control_freq, class="border border-gray-300 rounded px-1 py-0.5 w-16 text-xs") }}
+          {{ form.max_control_freq(size=1, step="0.001", min=0, max=1, default=sample.filters.max_control_freq, class="border border-gray-300 rounded px-1 py-0.5 w-16 text-xs") }}
         </div>
       </div>
 
@@ -106,7 +106,7 @@
         <label class="text-gray-900">Max Pop. Freq.</label>
         <div class="flex items-center gap-1">
           <span class="text-sm font-bold">&le;</span>
-          {{ form.max_popfreq(size=1, step="0.01", min=0, max=1, default=sample.filters.max_popfreq, class="border border-gray-300 rounded px-1 py-0.5 w-16 text-xs") }}
+          {{ form.max_popfreq(size=1, step="0.001", min=0, max=1, default=sample.filters.max_popfreq, class="border border-gray-300 rounded px-1 py-0.5 w-16 text-xs") }}
         </div>
       </div>
 
@@ -186,7 +186,7 @@
         <label class="text-gray-900">Gain Ratio</label>
         <div class="flex items-center gap-1">
           <span class="text-sm font-bold">&ge;</span>
-          {{ form.cnv_gain_cutoff(size=3, step="0.01", default=sample.filters.cnv_gain_cutoff,class="border border-gray-300 rounded px-2 py-0.5 w-24") }}
+          {{ form.cnv_gain_cutoff(size=3, step="0.001", default=sample.filters.cnv_gain_cutoff,class="border border-gray-300 rounded px-2 py-0.5 w-24") }}
         </div>
       </div>
 
@@ -195,7 +195,7 @@
         <label class="text-gray-900">Loss Ratio</label>
         <div class="flex items-center gap-1">
           <span class="text-sm font-bold">&le;</span>
-          {{ form.cnv_loss_cutoff(size=3, step="0.01", default=sample.filters.cnv_loss_cutoff, class="border border-gray-300 rounded px-2 py-0.5 w-24") }}
+          {{ form.cnv_loss_cutoff(size=3, step="0.001", default=sample.filters.cnv_loss_cutoff, class="border border-gray-300 rounded px-2 py-0.5 w-24") }}
         </div>
       </div>
 


### PR DESCRIPTION
# Summary
We changed the step size for the snv filters. Now it can go upto 0.001  which translates to 0.01% VAF.  Done this as per the request from the geneticist!

---

## Type of change
- [ ] Bug fix  
- [ ] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] New route / endpoint  
- [ ] Refactor / cleanup  
- [ ] UI/UX update  
- [ ] Documentation update  
- [ ] Infrastructure / CI/CD 

---

## Checklist (author)

### General
- [x] **CHANGELOG** updated with a clear entry  
- [x] **Version bumped** (if user-facing change)  
- [ ] Unit tests / integration tests added or updated  
- [ ] Affected routes tested in dev/stage with real data  
- [ ] Outputs verified (UI pages, DB writes, logs, etc.)  
- [ ] Documentation updated (developer + user docs if applicable)  
- [x] At least one reviewer has tested and approved the code 


Performed by:  
- [ ] Ram  
- [ ] Viktor  
- [x] Sailedra  
- [ ] (Add if missing)


---

## Review performed by
- [x] Ram  
- [ ] Viktor  
- [ ] Sailedra  
- [ ] (Add if missing)

---


