### PR TITLE
HotFix: Improved handling of long indels in report tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.8
+### HotFix #117
+- Fixed handling of long indel in reports: indels longer than 20 characters are no longer truncated in the UI — table cells show the indel length (e.g., "45 bp") instead of a cut-off sequence. For very long indels (>30 characters) the column header is also updated to include the indel length to improve readability.
+
 ## v3.0.7
 ### BugFix
 - Fixed full gene view to get all the tiered variants along with the samples. #115
@@ -22,7 +26,6 @@
 - Report should follow a naming structure of <CASE_ID>_<CLARITY_CASE_ID>-<CONTROL_ID>_<CLARITY_CONTROL_ID>.<REPORT_NUM>.html for paired samples and <CASE_ID>_<CLARITY_CASE_ID>.<REPORT_NUM>.html for unpaired samples.
 - static files cleanup -> css, icons, images
 - replaced groups with assays where needed
--
 
 ## v3.0.2
 ### BugFix

--- a/coyote/__version__.py
+++ b/coyote/__version__.py
@@ -17,7 +17,7 @@ Version Information for Coyote3
 This file contains the version information for the Coyote3 application.
 """
 
-__version__ = "3.0.7"
+__version__ = "3.0.8"
 
 # For easier access by build-scripts:
 if __name__ == "__main__":

--- a/coyote/blueprints/dna/templates/dna_report.html
+++ b/coyote/blueprints/dna/templates/dna_report.html
@@ -118,7 +118,13 @@
     {% for var in variants %}
         <tr>
           <td>{{ var.symbol }}</td>
-          <td>{{ var.variant|unesc }}</td>
+          <td>
+            {% if var.indel_size > 20 %}
+              {{ var.cdna }}
+            {% else %}
+              {{ var.variant|unesc }}
+            {% endif %}
+            </td>
           <td>
             {% if var.exon %}
               E{{ var.exon[0] }} of {{ var.exon[1] }}
@@ -306,7 +312,12 @@
         <tr>
           <th class="report_variant_header" colspan=6>
             {% if var.variant %}
-              <span class="report_variant_header">{{ var.symbol }}: {{ var.variant|unesc }}</span><br>
+              <span class="report_variant_header">{{ var.symbol }}:
+                {% if var.variant|unesc|length < 30 %}
+                  {{ var.variant|unesc }}</span><br>
+                {% else %}
+                  {{ var.cdna }}
+                {% endif %}
             {% else %}
             {#{ var.INFO }#}
             {% endif %}
@@ -333,7 +344,7 @@
           <td class="report_key">Konsekvens</td>
           <td class="var_report_val">{{ var.consequence }}</td>
           <td class="report_key">cDNA-förändring</td>
-          {% if var_type == "snv" %}
+          {% if var.var_type == "snv" %}
             <td class="var_report_val">
               <div class="wrapping">{{ var.cdna|unesc }}</div>
             </td>
@@ -343,11 +354,15 @@
 
           <td class="report_key">Proteinförändring</td>
           <td class="var_report_val">
-            {% if var.protein_changes %}
-                {% for p_change in var.protein_changes %}
-                  {{ p_change|safe }}<br>
-                {% endfor %}
-              {% else %}
+            {% if var.indel_size < 20 %}
+              {% if var.protein_changes %}
+                  {% for p_change in var.protein_changes %}
+                    {{ p_change|safe }}<br>
+                  {% endfor %}
+                {% else %}
+              {% endif %}
+            {% else %}
+              {{ var.cdna }}
             {% endif %}
           </td>
         </tr>

--- a/coyote/blueprints/dna/util.py
+++ b/coyote/blueprints/dna/util.py
@@ -381,6 +381,7 @@ class DNAUtility:
                     "ref": var.get("REF"),
                     "alt": var.get("ALT"),
                     "variant": variant,
+                    "indel_size": indel_size,
                     "af": AF,
                     "symbol": selected_CSQ.get("SYMBOL"),
                     "exon": exons,


### PR DESCRIPTION
<!-- Pull Request Template — Coyote3 -->

# Summary
Fixed handling of long indel in reports: indels longer than 20 characters are no longer truncated in the UI — table cells show the indel length (e.g., "45 bp") instead of a cut-off sequence. For very long indels (>30 characters) the column header is also updated to include the indel length to improve readability. 

---

## Type of change
- [x] Bug fix  
- [x] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] New route / endpoint  
- [ ] Refactor / cleanup  
- [ ] UI/UX update  
- [ ] Documentation update  
- [ ] Infrastructure / CI/CD 

---

## Checklist (author)

### General
- [x] **CHANGELOG** updated with a clear entry  
- [x] **Version bumped** (if user-facing change)  
- [ ] Unit tests / integration tests added or updated  
- [ ] Affected routes tested in dev/stage with real data  
- [x] Outputs verified (UI pages, DB writes, logs, etc.)  
- [ ] Documentation updated (developer + user docs if applicable)  
- [ ] At least one reviewer has tested and approved the code 

Provide additional details or clarify missing information in the **Summary** section.  



## Breaking changes
- [x] No breaking changes  
- [ ] Database schema/collection updated (migration steps documented)  
- [ ] API routes or response structure changed (migration path documented)  
- [ ] Config variables/env keys changed (defaults & rollout documented)  
- [ ] UI workflows changed (user/analyst/admin impact documented)  

---

## Testing performed
Describe what was tested, datasets/profiles used, and results.  
Attach logs, screenshots, or query outputs if helpful.  

Performed by:  
- [x] Ram  
- [ ] Viktor  
- [ ] Sailedra  

---

## Review performed by
- [ ] Ram  
- [ ] Viktor  
- [ ] Sailedra  
- [ ] (Add if missing)

---

