### PR TITLE
Use compact UTC timestamp (YYMMDDHHMMSS) for HTML report filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.1
+- Reports: HTML reports now use compact UTC timestamps in filenames to avoid collisions on re-runs.
+- New format <TUMOR_NAME>_<TUMOR_CLARITY_ID>-<NORMAL_NAME>_<NORMAL_CLARITY_ID>.<YYDDMMHHSS>.html for tumor-normal analysis.  <TUMOR_NAME>_<TUMOR_CLARITY_ID>.<YYDDMMHHSS>.html for tumor only analysis.
+
 ## v3.1.0 (Ongoing)
 ### Added
 - Sample landing page to view sample related meta data, case/control overview, files & QC, gene filters, variant filters, analysis data counts, reports, comments, etc.

--- a/coyote/__version__.py
+++ b/coyote/__version__.py
@@ -17,7 +17,7 @@ Version Information for Coyote3
 This file contains the version information for the Coyote3 application.
 """
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 # For easier access by build-scripts:
 if __name__ == "__main__":

--- a/coyote/blueprints/dna/templates/dna_report.html
+++ b/coyote/blueprints/dna/templates/dna_report.html
@@ -86,17 +86,23 @@
       <td class="top_report_val">{{ current_user.fullname }}</td>
     </tr>
     <tr>
-      {% set report_name = sample.get("name", "NONE") + "_" + sample.get("case", {}).get("clarity_id", "NONE") %}
+      {% set report_name = sample.get("case_id", "NONE") + "_" + sample.get("case", {}).get("clarity_id", "NONE") %}
       {% if sample.control_id %}
         {% set report_name = report_name + "-" + sample.get("control_id", "NONE") + "_" + sample.get("control",{}).get("clarity_id", "NONE") %}
       {% endif %}
-      <td class="top_report_key">Rapport-ID</td>
+      <td class="top_report_key">Rapportnummer</td>
       <td class="top_report_val">
         {% if sample.report_num is defined %}
-          {{ report_name }}.{{ sample.report_num + 1 }}
+          {{ sample.report_num + 1 }}
         {% else %}
-          {{ report_name }}.1
+          1
         {% endif %}
+      </td>
+    </tr>
+    <tr>
+      <td class="top_report_key">Rapport-ID</td>
+      <td class="top_report_val">
+        {{ report_name }}.{{ report_timestamp }}
       </td>
     </tr>
   </table>

--- a/coyote/blueprints/dna/util.py
+++ b/coyote/blueprints/dna/util.py
@@ -16,7 +16,7 @@ It includes methods for variant classification, consequence selection, CNV handl
 """
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from flask_login import current_user
 from bson.objectid import ObjectId
 from coyote.util.common_utility import CommonUtility
@@ -496,3 +496,13 @@ class DNAUtility:
                     var["other_genes"].append(gene["gene"])
             fixed_cnvs_genes.append(var)
         return fixed_cnvs_genes
+
+    @staticmethod
+    def get_report_timestamp() -> str:
+        """
+        This function returns the current timestamp, formatted as a string, which can be used to indicate when a report was generated. The timestamp includes the date and time down to the second.
+
+        Returns:
+            str: A string representing the current timestamp in the format 'YYYY-MM-DD HH:MM:SS'.
+        """
+        return datetime.now(timezone.utc).strftime("%y%m%d%H%M%S")

--- a/coyote/db/samples.py
+++ b/coyote/db/samples.py
@@ -536,19 +536,22 @@ class SampleHandler(BaseHandler):
         """
         return self.get_collection().delete_one({"_id": ObjectId(sample_oid)})
 
-    def save_report(self, sample_id: str, report_id: str, filepath: str) -> bool | None:
+    def save_report(
+        self, sample_id: str, report_num: int, report_id: str, filepath: str
+    ) -> bool | None:
         """
         Save a report to a sample document in the database.
 
         Args:
             sample_id (str): The unique identifier of the sample.
+            report_num (int): The current running report number.
             report_id (str): The unique identifier of the report to save.
             filepath (str): The file path where the report is stored.
 
         Returns:
             bool | None: Returns the result of the database update operation.
         """
-        report_num = int(report_id.split(".")[-1])
+        # report_num = int(report_id.split(".")[-1])
         return self.get_collection().update(
             {"name": sample_id},
             {


### PR DESCRIPTION

# Summary
This PR updates HTML report naming to use a compact, UTC-based timestamp (YYMMDDHHMMSS), preventing filename collisions when samples are reprocessed while preserving backward compatibility with existing report discovery logic. 

---

## Type of change
- [x] Bug fix  
- [x] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] New route / endpoint  
- [ ] Refactor / cleanup  
- [ ] UI/UX update  
- [ ] Documentation update  
- [ ] Infrastructure / CI/CD 

---

## Checklist (author)

### General
- [x] **CHANGELOG** updated with a clear entry  
- [x] **Version bumped** (if user-facing change)  
- [ ] Unit tests / integration tests added or updated  
- [x] Affected routes tested in dev/stage with real data  
- [x] Outputs verified (UI pages, DB writes, logs, etc.)  
- [ ] Documentation updated (developer + user docs if applicable)  
- [ ] At least one reviewer has tested and approved the code 

Provide additional details or clarify missing information in the **Summary** section.  

---  
  
## Breaking changes
- [x] No breaking changes  
- [ ] Database schema/collection updated (migration steps documented)  
- [ ] API routes or response structure changed (migration path documented)  
- [ ] Config variables/env keys changed (defaults & rollout documented)  
- [ ] UI workflows changed (user/analyst/admin impact documented)  

---

## Testing performed
Performed by:  
- [x] Ram  
- [ ] Viktor  
- [ ] Sailedra  
- [ ] (Add if missing)

---

## Review performed by
- [ ] Ram  
- [ ] Viktor  
- [ ] Sailedra  
- [ ] (Add if missing)

---

