### PR TITLE
Fix ObjectId serialization and restoration in admin sample JSON editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.1.2
+- Admin: Fixed JSON sample editor to safely serialize and restore MongoDB ObjectIds during full document updates.
+
 ## v3.1.1
 - Reports: HTML reports now use compact UTC timestamps in filenames to avoid collisions on re-runs.
 - New format <TUMOR_NAME>_<TUMOR_CLARITY_ID>-<NORMAL_NAME>_<NORMAL_CLARITY_ID>.<YYDDMMHHSS>.html for tumor-normal analysis.  <TUMOR_NAME>_<TUMOR_CLARITY_ID>.<YYDDMMHHSS>.html for tumor only analysis.

--- a/coyote/__version__.py
+++ b/coyote/__version__.py
@@ -17,7 +17,7 @@ Version Information for Coyote3
 This file contains the version information for the Coyote3 application.
 """
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 
 # For easier access by build-scripts:
 if __name__ == "__main__":

--- a/coyote/blueprints/admin/filters.py
+++ b/coyote/blueprints/admin/filters.py
@@ -52,11 +52,7 @@ def pretty_json_filter(value: Any) -> Markup:
     Returns:
         Markup: HTML-safe, pretty-printed JSON string.
     """
-    return Markup(
-        json.dumps(
-            value, indent=2, ensure_ascii=False, cls=EnhancedJSONEncoder
-        )
-    )
+    return Markup(json.dumps(value, indent=2, ensure_ascii=False, cls=EnhancedJSONEncoder))
 
 
 @app.template_filter("safejson")

--- a/coyote/blueprints/admin/views.py
+++ b/coyote/blueprints/admin/views.py
@@ -119,6 +119,7 @@ def edit_sample(sample_id: str) -> str | Response:
 
         try:
             # Ensure the schema _id remains intact
+            updated_sample = util.admin.restore_objectids(deepcopy(updated_sample))
             updated_sample["_id"] = sample_obj
             store.sample_handler.update_sample(sample_obj, updated_sample)
             flash("Sample updated successfully.", "green")

--- a/coyote/util/misc.py
+++ b/coyote/util/misc.py
@@ -35,6 +35,7 @@ from flask_login import current_user
 from flask import flash, redirect, url_for
 from flask import current_app as app
 from copy import deepcopy
+from bson import ObjectId
 
 
 # -------------------------------------------------------------------------
@@ -69,6 +70,10 @@ class EnhancedJSONEncoder(json.JSONEncoder):
         """
         if isinstance(obj, datetime):
             return obj.isoformat()  # or use obj.strftime(...) for a custom format
+
+        if isinstance(obj, ObjectId):
+            return str(obj)
+
         return super().default(obj)
 
 


### PR DESCRIPTION
<!-- Pull Request Template — Coyote3 -->

# Summary
This PR fixes the admin sample JSON editor by properly serializing MongoDB ObjectId values for display and restoring them before saving, ensuring full document replacements preserve ObjectId types and preventing data corruption or serialization errors.  

---

## Type of change
- [x] Bug fix  
- [ ] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] New route / endpoint  
- [ ] Refactor / cleanup  
- [ ] UI/UX update  
- [ ] Documentation update  
- [ ] Infrastructure / CI/CD 

---

## Checklist (author)

### General
- [x] **CHANGELOG** updated with a clear entry  
- [x] **Version bumped** (if user-facing change)  
- [ ] Unit tests / integration tests added or updated  
- [ ] Affected routes tested in dev/stage with real data  
- [ ] Outputs verified (UI pages, DB writes, logs, etc.)  
- [ ] Documentation updated (developer + user docs if applicable)  
- [ ] At least one reviewer has tested and approved the code 

Provide additional details or clarify missing information in the **Summary** section.  

---  


## Breaking changes
- [x] No breaking changes  
- [ ] Database schema/collection updated (migration steps documented)  
- [ ] API routes or response structure changed (migration path documented)  
- [ ] Config variables/env keys changed (defaults & rollout documented)  
- [ ] UI workflows changed (user/analyst/admin impact documented)  

---

## Testing performed
Yes, on test samples

Performed by:  
- [x] Ram  
- [ ] Viktor  
- [ ] Sailedra  
- [ ] (Add if missing)

---

## Review performed by
- [ ] Ram  
- [ ] Viktor  
- [ ] Sailedra  
- [ ] (Add if missing)


